### PR TITLE
✨ [CW-21055] feat: add get card info container

### DIFF
--- a/src/DemoAppNavigator.tsx
+++ b/src/DemoAppNavigator.tsx
@@ -16,11 +16,13 @@ import { EIP1559TokenTransferContainer } from '@src/features/tx/EIP1559TokenTran
 import { GetPairedAppsContainer } from '@src/features/cardPairing/GetPairedAppsContainer';
 import { RefreshAppKeyPairContainer } from '@src/features/cardPairing/RefreshAppKeyPairContainer';
 import { GeneratePairingPasswordContainer } from '@src/features/cardPairing/GeneratePairingPasswordContainer';
+import { GetCardInfoContainer } from '@src/features/cardPairing/GetCardInfoContainer';
 
 export type DemoAppParamList = {
   [RouteName.DEMO_HOME]: undefined;
   [RouteName.BLUETOOTH_SCAN]: undefined;
   [RouteName.REFRESH_APP_KEY_PAIR]: undefined;
+  [RouteName.GET_CARD_INFO]: undefined;
   [RouteName.RESET_CARD]: undefined;
   [RouteName.REGISTER_CARD]: undefined;
   [RouteName.RECOVER_MNEMONIC]: undefined;
@@ -63,6 +65,7 @@ export function DemoAppNavigator() {
         options={{ headerBackTitleVisible: false }}
       />
       <Stack.Screen name={RouteName.RESET_CARD} component={ResetCardContainer} options={{ headerBackTitleVisible: false }} />
+      <Stack.Screen name={RouteName.GET_CARD_INFO} component={GetCardInfoContainer} options={{ headerBackTitleVisible: false }} />
       <Stack.Screen
         name={RouteName.REGISTER_CARD}
         component={RegisterCardContainer}
@@ -93,7 +96,11 @@ export function DemoAppNavigator() {
         component={GeneratePairingPasswordContainer}
         options={{ headerBackTitleVisible: false }}
       />
-      <Stack.Screen name={RouteName.REFRESH_APP_KEY_PAIR} component={RefreshAppKeyPairContainer} options={{ headerBackTitleVisible: false }} />
+      <Stack.Screen
+        name={RouteName.REFRESH_APP_KEY_PAIR}
+        component={RefreshAppKeyPairContainer}
+        options={{ headerBackTitleVisible: false }}
+      />
       <Stack.Screen
         name={RouteName.EIP1559_COIN}
         component={EIP1559CoinTransferContainer}

--- a/src/features/ble/data/CardInfo.ts
+++ b/src/features/ble/data/CardInfo.ts
@@ -6,5 +6,5 @@ export interface CardInfo {
   pairRemainTimes: number; // indicates the number of remaining pairing attempts allowed, with a maximum of 5 attempts
   accountDigest: string; // indicates the first 10 digits of the card's seed. Restoring with the same mnemonic will yield the same result
   accountDigest20?: string; // similar to accountDigest, but displays the first 20 digits of the card's seed.
-  cardanoSeed?: boolean; // indicates whether the Cardano seed has been imported.
+  cardanoSeed?: string; // indicates whether the Cardano seed has been imported.
 }

--- a/src/features/ble/data/CardInfo.ts
+++ b/src/features/ble/data/CardInfo.ts
@@ -1,0 +1,10 @@
+export interface CardInfo {
+  paired: boolean; // indicates whether the card has been paired before
+  locked: boolean; // indicates whether the card has been locked due to too many incorrect password attempts
+  walletCreated: boolean; // indicates whether a wallet has been created by restoring from a seed
+  showDetail: boolean; // indicates whether the counterparty's address is displayed during card transactions
+  pairRemainTimes: number; // indicates the number of remaining pairing attempts allowed, with a maximum of 5 attempts
+  accountDigest: string; // indicates the first 10 digits of the card's seed. Restoring with the same mnemonic will yield the same result
+  accountDigest20?: string; // similar to accountDigest, but displays the first 20 digits of the card's seed.
+  cardanoSeed?: boolean; // indicates whether the Cardano seed has been imported.
+}

--- a/src/features/ble/data/PairedApp.ts
+++ b/src/features/ble/data/PairedApp.ts
@@ -1,0 +1,4 @@
+export interface PairedApp {
+  appId: string;
+  deviceName: string;
+}

--- a/src/features/ble/data/RegisterInfo.ts
+++ b/src/features/ble/data/RegisterInfo.ts
@@ -1,0 +1,5 @@
+export interface RegisterInfo {
+  deviceName: string;
+  password: string;
+  appId: string;
+}

--- a/src/features/cardPairing/GetCardInfoContainer.tsx
+++ b/src/features/cardPairing/GetCardInfoContainer.tsx
@@ -1,0 +1,82 @@
+import { RNApduError } from '@src/features/ble/RNApduError';
+import { useGetCardInfoUseCase } from '@src/features/cardPairing/usecases/useGetCardInfoUseCase';
+import { BlueButton } from '@src/features/components/BlueButton';
+import { LogBox } from '@src/features/components/LogBox';
+import { TextView } from '@src/features/components/TextView';
+import { useLogUseCase } from '@src/features/home/usecases/useLogUseCase';
+import { useCardId, useIsConnected } from '@src/features/store/device/DeviceActionHooks';
+import { VStack } from 'native-base';
+import React from 'react';
+import { View } from 'react-native';
+import styled from 'styled-components';
+
+const Layout = styled(View)`
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  margin-top: 24px;
+  padding-horizontal: 20px;
+  padding-bottom: 100px;
+`;
+
+const ButtonLayout = styled(View)`
+  flex-direction: row;
+  justify-content: space-between;
+`;
+
+const Button = styled(BlueButton)`
+  margin-top: 8px;
+`;
+
+export function GetCardInfoContainer(): JSX.Element {
+  const cardId = useCardId();
+  const isConnected = useIsConnected();
+  const { getCardInfo, isQuerying } = useGetCardInfoUseCase();
+  const isBtnDisable = !isConnected || isQuerying;
+  const { log, addLog, resetLog } = useLogUseCase();
+
+  const onClick = () => {
+    resetLog();
+    addLog('QUERYING....');
+    getCardInfo()
+      .then((cardInfo) => {
+        addLog('QUERIED SUCCESS');
+        addLog(`paired: ${cardInfo.paired}\r\n// Indicates whether the card has been paired before.`);
+        addLog(
+          `locked: ${cardInfo.locked}\r\n// Indicates whether the card has been locked due to too many incorrect password attempts.`,
+        );
+        addLog(
+          `walletCreated: ${cardInfo.walletCreated}\r\n// Indicates whether a wallet has been created by restoring from a seed.`,
+        );
+        addLog(
+          `showDetail: ${cardInfo.showDetail}\r\n// Indicates whether the counterparty's address is displayed during card transactions.`,
+        );
+        addLog(
+          `pairRemainTimes: ${cardInfo.pairRemainTimes}\r\n// Indicates the number of remaining pairing attempts allowed, with a maximum of 5 attempts.`,
+        );
+        addLog(
+          `accountDigest: ${cardInfo.accountDigest}\r\n// Indicates the first 10 digits of the card's seed. Restoring with the same mnemonic will yield the same result.`,
+        );
+        if (cardInfo.accountDigest20)
+          addLog(
+            `accountDigest20: ${cardInfo.accountDigest20}\r\n// Similar to accountDigest, but displays the first 20 digits of the card's seed.`,
+          );
+        addLog(`cardanoSeed: ${cardInfo.cardanoSeed}\r\n// Indicates whether the Cardano seed has been imported.`);
+      })
+      .catch((e) => {
+        const error = e as RNApduError;
+        addLog('QUERIED FAILED >>> ERROR=' + error);
+      });
+  };
+  return (
+    <Layout>
+      <VStack space={3} justifyContent="center" alignContent="flex-start" w={'100%'}>
+        <LogBox log={log} size={0.6} />
+        <TextView text={cardId} placeholder="Card Id" />
+        <ButtonLayout>
+          <Button isLoading={isQuerying} disabled={isBtnDisable} onClicked={onClick} text={'Get Card Info'} />
+        </ButtonLayout>
+      </VStack>
+    </Layout>
+  );
+}

--- a/src/features/cardPairing/GetPairedAppsContainer.tsx
+++ b/src/features/cardPairing/GetPairedAppsContainer.tsx
@@ -1,6 +1,7 @@
 import { useNavigation } from '@react-navigation/native';
 import { RNApduError } from '@src/features/ble/RNApduError';
-import { PairedApp, RNApduManager } from '@src/features/ble/RNApduManager';
+import { RNApduManager } from '@src/features/ble/RNApduManager';
+import { PairedApp } from '@src/features/ble/data/PairedApp';
 import { PairedAppsView } from '@src/features/components/PairedAppsView';
 import { useInitApduEffect } from '@src/features/home/usecases/useCardPairingUseCase';
 import { useLogUseCase } from '@src/features/home/usecases/useLogUseCase';

--- a/src/features/cardPairing/usecases/useGetCardInfoUseCase.ts
+++ b/src/features/cardPairing/usecases/useGetCardInfoUseCase.ts
@@ -1,0 +1,29 @@
+import { RNApduManager } from '@src/features/ble/RNApduManager';
+import { CardInfo } from '@src/features/ble/data/CardInfo';
+import { useInitApduEffect } from '@src/features/home/usecases/useCardPairingUseCase';
+import { useState } from 'react';
+
+interface GetCardInfoOutput {
+  isQuerying: boolean;
+  cardInfo?: CardInfo;
+  getCardInfo: () => Promise<CardInfo>;
+}
+export function useGetCardInfoUseCase(): GetCardInfoOutput {
+  const [isQuerying, setIsQuerying] = useState(false);
+  const [cardInfo, setCardInfo] = useState<CardInfo>();
+  useInitApduEffect();
+
+  const getCardInfo = async () => {
+    setIsQuerying(true);
+    const result = await RNApduManager.getInstance().getCardInfo();
+    setCardInfo(result);
+    setIsQuerying(false);
+    return result;
+  };
+
+  return {
+    cardInfo,
+    isQuerying,
+    getCardInfo,
+  };
+}

--- a/src/features/components/AppItem.tsx
+++ b/src/features/components/AppItem.tsx
@@ -1,4 +1,4 @@
-import { PairedApp } from '@src/features/ble/RNApduManager';
+import { PairedApp } from '@src/features/ble/data/PairedApp';
 import { AppIcon } from '@src/features/components/AppIcon';
 import { StarIcon } from '@src/features/components/StarIcon';
 import React from 'react';

--- a/src/features/components/PairedAppsView.tsx
+++ b/src/features/components/PairedAppsView.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { ViewStyle, View, ScrollView, RefreshControl, Platform } from 'react-native';
 import styled from 'styled-components/native';
 import { Button, Text, VStack } from 'native-base';
-import { PairedApp } from '@src/features/ble/RNApduManager';
 import { AppItem } from '@src/features/components/AppItem';
 import { LogBox, getDefaultLog } from '@src/features/components/LogBox';
+import { PairedApp } from '@src/features/ble/data/PairedApp';
 
 const StyledButton = styled(Button)`
   width: 90px;

--- a/src/features/home/CardPairingContainer.tsx
+++ b/src/features/home/CardPairingContainer.tsx
@@ -7,6 +7,10 @@ function useRouteItems() {
   const navigation = useNavigation<NavigationProp<DemoAppParamList>>();
   const routeItems: Array<RouteItem> = [
     {
+      routeName: RouteName.GET_CARD_INFO,
+      onButtonPress: () => navigation.navigate(RouteName.GET_CARD_INFO),
+    },
+    {
       routeName: RouteName.RESET_CARD,
       onButtonPress: () => navigation.navigate(RouteName.RESET_CARD),
     },

--- a/src/features/home/usecases/useLogUseCase.ts
+++ b/src/features/home/usecases/useLogUseCase.ts
@@ -4,6 +4,7 @@ import { useEffect } from 'react';
 interface LogOutput {
   log?: string;
   addLog: (newLog: string) => void;
+  resetLog: () => void;
 }
 export function useLogUseCase(): LogOutput {
   const log = useLog();
@@ -17,5 +18,6 @@ export function useLogUseCase(): LogOutput {
   return {
     log,
     addLog,
+    resetLog,
   };
 }

--- a/src/features/store/account/AccountActionHooks.ts
+++ b/src/features/store/account/AccountActionHooks.ts
@@ -79,7 +79,7 @@ export function useAddress(cardId?: string, index?: number) {
   return account.addresses?.[index as number] || '';
 }
 
-export function useDispatchChangeAppInfo(): (cardId: string, appId: string, password: string, deviceName?: string) => void {
+export function useDispatchChangeAppInfo(): (cardId: string, appId: string, password: string, deviceName: string) => void {
   const dispatch = useAppDispatch();
   return (cardId, appId, password, deviceName) => {
     dispatch(AccountActions.setAppInfo({ cardId, deviceName, appId, password }));

--- a/src/features/store/account/AccountSlice.ts
+++ b/src/features/store/account/AccountSlice.ts
@@ -19,13 +19,13 @@ export const AcountSlice = createSlice({
     },
     setAppInfo: (
       state: AccountState,
-      action: PayloadAction<{ cardId: string; appId: string; password: string; deviceName?: string }>,
+      action: PayloadAction<{ cardId: string; appId: string; deviceName: string; password: string }>,
     ) => {
       const { cardId, deviceName, appId, password } = action.payload;
       const accountInfo: AccountInfo = {
         isWalletRecovered: false,
         appId,
-        deviceName: deviceName || cardId,
+        deviceName,
         password,
         addresses: {},
       };

--- a/src/routes/type.ts
+++ b/src/routes/type.ts
@@ -3,6 +3,7 @@ export enum RouteName {
   BLUETOOTH_SCAN = 'BluetoothScan',
   REFRESH_APP_KEY_PAIR = 'Refresh App Key Pair',
   RESET_CARD = 'Reset Card',
+  GET_CARD_INFO = 'Get Card Info',
   REGISTER_CARD = 'Register Card',
   CREATE_MNEMONIC = 'Create Mnemonic',
   RECOVER_MNEMONIC = 'Recover Mnemonic',


### PR DESCRIPTION
## 調整項目
1. add getCardInfoUseCase
2. add getCardInfoContainer
3. addLogUseCase 增加 resetLog 介面
4. 新增 data 資料夾放 SDK 會回傳的資料型別
5. redux 的 deviceName 改為必填，移除為空會幫帶入 cardId 邏輯

## 實機圖
<Image src="https://github.com/CoolBitX-Technology/coolwallet-app-demo/assets/7089206/966bcca5-dc4f-489c-a582-22b82ee39181" width="350" height="750" />

## 備註
發現 cardanoSeed 欄位應該為布林，但介面是定義字串
