### PR TITLE
🐛 fix: 因為 pod 版本不一致，導致無法安裝的問題

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -503,7 +503,7 @@ PODS:
     - React-perflogger (= 0.72.4)
   - RNCAsyncStorage (1.23.1):
     - React-Core
-  - RNCClipboard (1.14.1):
+  - RNCClipboard (1.11.2):
     - React-Core
   - RNGestureHandler (2.16.2):
     - RCT-Folly (= 2021.07.22.00)
@@ -790,7 +790,7 @@ SPEC CHECKSUMS:
   React-utils: b79f2411931f9d3ea5781404dcbb2fa8a837e13a
   ReactCommon: 4b2bdcb50a3543e1c2b2849ad44533686610826d
   RNCAsyncStorage: 826b603ae9c0f88b5ac4e956801f755109fa4d5c
-  RNCClipboard: 0a720adef5ec193aa0e3de24c3977222c7e52a37
+  RNCClipboard: 3f0451a8100393908bea5c5c5b16f96d45f30bfc
   RNGestureHandler: d678f94a8f74de70ce3d9f5d23eb0f97b686e943
   RNOS: 94330d67e75b1ffa26ac81dc46b69a85658322b5
   RNPermissions: 81313be373597856123b55d0842c0e2474366218
@@ -803,4 +803,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 83bfca70b10edfc3bd213446b108efe8e3c50147
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.12.1

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@coolwallet/core": "^1.1.18",
     "@coolwallet/evm": "^1.0.27",
     "@react-native-async-storage/async-storage": "^1.19.2",
-    "@react-native-clipboard/clipboard": "^1.11.2",
+    "@react-native-clipboard/clipboard": "1.11.2",
     "@react-navigation/material-top-tabs": "^6.6.3",
     "@react-navigation/native": "^6.1.7",
     "@react-navigation/native-stack": "^6.9.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2284,10 +2284,10 @@
   dependencies:
     merge-options "^3.0.4"
 
-"@react-native-clipboard/clipboard@^1.11.2":
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/@react-native-clipboard/clipboard/-/clipboard-1.14.1.tgz#835f82fc86881a0808a8405f2576617bb5383554"
-  integrity sha512-SM3el0A28SwoeJljVNhF217o0nI4E7RfalLmuRQcT1/7tGcxUjgFa3jyrEndYUct8/uxxK5EUNGUu1YEDqzxqw==
+"@react-native-clipboard/clipboard@1.11.2":
+  version "1.11.2"
+  resolved "https://registry.yarnpkg.com/@react-native-clipboard/clipboard/-/clipboard-1.11.2.tgz#e826d0336b34e67294aaffa6878308900bc7d197"
+  integrity sha512-bHyZVW62TuleiZsXNHS1Pv16fWc0fh8O9WvBzl4h2fykqZRW9a+Pv/RGTH56E3X2PqzHP38K5go8zmCZUoIsoQ==
 
 "@react-native-community/cli-clean@11.3.6":
   version "11.3.6"


### PR DESCRIPTION
使用 pod 1.1.12.1 的人較多，先改回舊版，RNCClipboard  1.14.1 要新版本的 pod 1.15.2 才支援